### PR TITLE
Fixing save/restore as seen if you save in uninvited.z5 and then rest…

### DIFF
--- a/frotz_quetzal.c
+++ b/frotz_quetzal.c
@@ -539,7 +539,7 @@ zword save_quetzal (FILE *svf, FILE *stf)
 	    || !write_word (svf, nstk))			return 0;
 
 	/* Write the variables and eval stack. */
-	for (j=0, ++p; j<nvars+nstk; ++j, --p)
+	for (j=0, --p; j<nvars+nstk; ++j, --p)
 	    if (!write_word (svf, *p))			return 0;
 
 	/* Calculate length written thus far. */


### PR DESCRIPTION
…ore.

I reported this bug to David Griffith for Frotz a year or so back.  I pulled the fix from Windows Frotz.  to reproduce the bug, download uninvited.z5 from the if-archive, start the game, and at the first turn, save the game, then restore the game.  After that, if you type look, a stream of errors comes out.  Changing the ++p to a --p fixes the issue.  I think this is in the code that stores the stack, so I'm not sure why the bug doesn't seem to show up in other games.